### PR TITLE
Add Hero2 info section without image

### DIFF
--- a/src/components/Hero2.css
+++ b/src/components/Hero2.css
@@ -1,0 +1,13 @@
+.hero2-content {
+  max-width: 800px;
+  color: white;
+}
+
+.hero2-content ul {
+  padding-left: 1rem;
+  text-align: left;
+}
+
+.hero2-content li {
+  margin-bottom: 0.25rem;
+}

--- a/src/components/Hero2.jsx
+++ b/src/components/Hero2.jsx
@@ -1,0 +1,34 @@
+import './Hero2.css';
+
+export default function Hero2() {
+  return (
+    <section
+      id="hero2"
+      className="d-flex align-items-center justify-content-center text-center"
+      style={{
+        height: '100vh',
+        backgroundImage: "url('/hero2.jpg')",
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundColor: '#000',
+      }}
+    >
+      <div data-aos="fade-up" className="hero2-content p-4 bg-dark bg-opacity-50 rounded">
+        <p className="mb-3">
+          Un paraíso natural para descansar al frente del mar , desconectar y disfrutar de la magia del Pacifico Chocoano.
+        </p>
+        <p className="mb-4">
+          En el corazón del Pacífico colombiano, en el corregimiento del valle, Bahía Solano, en playa Cuevita en el sector de Coredó a 30 minutos del Parque Nacional Natural Utría, con 9 kilometros de playas casi vírgenes  Origen Zelvamar te ofrece una experiencia única:
+        </p>
+        <ul className="list-unstyled mb-0">
+          <li>6 cabañas privadas frente al mar </li>
+          <li>Baño privado</li>
+          <li>Balcón con vista a la playa  y la selva</li>
+          <li>Entorno tranquilo y 100% natural</li>
+          <li>Gastronomía Local </li>
+          <li>Privacidad, silencio y confort</li>
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,6 @@
 import Navbar from '../components/Navbar';
 import Hero from '../components/Hero';
+import Hero2 from '../components/Hero2';
 import Rooms from '../components/Rooms';
 import CarouselCard from '../components/CarouselCard';
 import Contact from '../components/Contact';
@@ -11,6 +12,7 @@ export default function Home() {
     <>
       <Navbar />
       <Hero />
+      <Hero2 />
 
    <div style={{ overflow: 'hidden', lineHeight: 0 }}>
       <svg viewBox="0 0 1440 320" style={{ width: '100%', height: '100px' }} preserveAspectRatio="none">


### PR DESCRIPTION
## Summary
- create Hero2 component with background text and fade-up animation
- include Hero2 styles
- insert Hero2 component in home page
- remove hero2.jpg since it's already in repository

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686472a1fed08324b894d7593be00853