### PR TITLE
Return to simple scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4",
-    "@fullpage/react-fullpage": "^0.1.17"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/index.css
+++ b/src/index.css
@@ -14,13 +14,7 @@ body {
 
 html,
 body {
-  scroll-behavior: smooth;
-  scroll-snap-type: y mandatory;
-}
-
-section {
-  scroll-snap-align: start;
-  scroll-margin-top: 80px;
+  scroll-behavior: auto;
 }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import MainApp from './MainApp';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'aos/dist/aos.css';
-import '@fullpage/react-fullpage/dist/react-fullpage.css';
 import './index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,44 +7,19 @@ import Precios from '../components/Precios';
 import CarouselCard from '../components/CarouselCard';
 import Contact from '../components/Contact';
 import Footer from '../components/Footer';
-import ReactFullpage from '@fullpage/react-fullpage';
 
 export default function Home() {
   return (
     <>
       <Navbar />
-      <ReactFullpage
-        navigation
-        scrollingSpeed={700}
-        render={() => (
-          <ReactFullpage.Wrapper>
-            <div className="section">
-              <Hero />
-            </div>
-            <div className="section">
-              <Hero2 />
-            </div>
-            <div className="section">
-              <MapaZelvamar />
-            </div>
-            <div className="section">
-              <Rooms />
-            </div>
-            <div className="section">
-              <Precios />
-            </div>
-            <div className="section">
-              <CarouselCard />
-            </div>
-            <div className="section">
-              <Contact />
-            </div>
-            <div className="section">
-              <Footer />
-            </div>
-          </ReactFullpage.Wrapper>
-        )}
-      />
+      <Hero />
+      <Hero2 />
+      <MapaZelvamar />
+      <Rooms />
+      <Precios />
+      <CarouselCard />
+      <Contact />
+      <Footer />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- remove ReactFullpage dependency
- simplify `Home` layout to normal scrolling
- drop fullpage CSS import from `index.js`
- revert scroll snap rules in `index.css`

## Testing
- `npm test --silent --prefix ./` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865734cc5508324b6f30bc4b138a13f